### PR TITLE
ignore local ruby version manager files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ test/tmp
 test/version_tmp
 tmp
 .idea/
+.ruby-gemset
+.ruby-version
+.rvmrc


### PR DESCRIPTION
When using tools like rvm, rbenv and others, it is useful to have
projects auto-setup based on the requirements of the project (selecting
a specific Ruby version, using a particular set of gems).

This helps keep the local developemnt environment from reporting "git
dirty" status.
